### PR TITLE
Restyle Exposure with editorial design + quick fixes

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,248 +1,101 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Pay me in Exposure</title>
-  <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Pay in Exposure</title>
 
-  <meta name="description" content="The simplest payment processing system">
-  <meta name="author" content="Exposure">
-  <meta property="og:title" content="Exposure">
-  <meta property="og:description" content="A simple, minimal payment processing system that allows you to pay in Exposure.">
-  <meta property="og:url" content="https://exposure.money/">
-  <meta property="og:type" content="website">
-  <meta property="og:image" content="exposure.png">
+  <meta name="description" content="The simplest, minimal payment system that lets you pay in Exposure." />
+  <meta name="author" content="Exposure" />
 
-  <meta name="twitter:site" content="@mimosaagency">
-  <meta name="twitter:title" content="Exposure">
-  <meta name="twitter:description" content="The simplest payment processing system.">
-  <meta name="twitter:url" content="https://exposure.money/">
-  <meta name="twitter:card" content="photo">
-  <meta name="twitter:image src" content="https://github.com/danilosierrac/exposure/blob/master/exposure.png?raw=true" />
+  <meta property="og:title" content="Exposure" />
+  <meta property="og:description" content="A simple, minimal payment system that lets you pay in Exposure." />
+  <meta property="og:url" content="https://exposure.money/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://github.com/danilosierrac/exposure/blob/master/exposure.png?raw=true" />
 
-  <head profile="https://www.w3.org/2005/10/profile">
-  <link rel="icon" 
-      type="image/png" 
-      href="exposure.ico">
-<link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
-<style>
-body {
-  font-family: -apple-system, "San Francisco", BlinkMacSystemFont, “Segoe UI”, Roboto, Helvetica, Arial, sans-serif, “Apple Color Emoji”, “Segoe UI Emoji”, “Segoe UI Symbol”; 
-  max-width: 80%; 
-  margin-left: 10%;
-  word-wrap: break-word;
-}
+  <meta name="twitter:site" content="@mimosaagency" />
+  <meta name="twitter:title" content="Exposure" />
+  <meta name="twitter:description" content="The simplest payment system." />
+  <meta name="twitter:url" content="https://exposure.money/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://github.com/danilosierrac/exposure/blob/master/exposure.png?raw=true" />
 
-input[type="text"] 
-{
-  margin-top: 30px;
-  margin-bottom: 30px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 10px;
-  border: none;
-  text-align: left;
-  border-bottom: dashed 5px #FF2D55;
-  transition: border 0.3s;
-  color: #FF2D55;
-  word-wrap: break-word;
-  box-sizing : border-box;
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-  background-color: #ededed;
-}
-
-input[type="text"]:enabled,
-  input[type="text"].enabled {
-  margin-top: 30px;
-  margin-bottom: 30px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 10px;
-  border-bottom: dashed 5px #FF2D55;
-  font-size: 1em;
-  color: #FF2D55;
-  word-wrap: break-word;
-  box-sizing : border-box;
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-  background-color: #ededed;
-}
-
-  input[type="text"]:focus,
-  input[type="text"].focus {
-
-  margin-top: 30px;
-  margin-bottom: 30px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 10px;
-  border-bottom: dashed 5px #FF2D55;
-  font-size: 1em;
-  color: #FF2D55;
-  word-wrap: break-word;
-  box-sizing : border-box;
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-  background-color: #ededed;
-}
-
-input[type="text"]:blur,
-  input[type="text"].blur {
-  margin-top: 30px;
-  margin-bottom: 30px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 10px;
-  margin-bottom: 20px;
-  border-bottom: solid 5px #FF2D55;
-  font-size: 1.8em;
-  color: #FF2D55;
-  word-wrap: break-word;
-  box-sizing : border-box;
-  background-color: #ededed;
-}
-
-Button {
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-  background-color:#ff2d54;
-  display:inline-block;
-  cursor:pointer;
-  color:#ffffff;
-  font-family:Arial;
-  font-size:17px;
-  padding:16px 31px;
-  text-decoration:none;
-  border: none;
-  font-size: 3em;
-}
-
-Button:hover {
-  background-color:#ff2d54;
-}
-Button:active {
-  position:relative;
-  top:1px;
-}
-
-
-hr 
-{
-   border: 0;
-    height: 2px;
-    background: #333;
-    background-color: #333;
-}
-
-h1{
-  font-size: 8em;
-  color: #FF2D55;
-  text-decoration: underline;
-}
-
-h2 {
-  font-size: 4em;
-}
-
-p {
-  font-size: 3em;
-}
-
-pre{
-  margin-top: 30px;
-  padding: 20px 10px 20px 10px;
-  color: #FF2D55;
-  background-color: transparent;
-  background-color: #ededed;
-  outline: 0;
-  border-radius: 0;
-  resize: both;
-  overflow: auto;
-  font-size: 3em;
-  border-bottom: dashed 5px #FF2D55;
-  box-sizing : border-box;
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-}
-
-div {
-/*  padding-top: 2%;*/
-  padding-bottom: 5%;
-  margin: auto;
-}
-
-
-
-</style>
+  <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
 </head>
 
 <body>
-  <!-- &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -->
+  <div class="wrap">
+    <header class="topbar">
+      <a class="mark" href="https://exposure.money">Exposure</a>
+      <span class="caption">exposure.money</span>
+    </header>
 
-  <div id="error" style="display:none;">
-    <h2>😵 Whoops! Something went wrong with that link.</h2>
-    <p>Please use only your USER ID and nothing else in the field. </p> 
+    <!-- Error state -->
+    <div id="error" class="pay-screen" style="display:none;">
+      <p class="eyebrow">Whoops</p>
+      <h1 class="display">Bad link.</h1>
+      <p>That payment link didn't decode. It should contain only a PayPal.Me user ID and an amount — nothing else.</p>
+      <div class="pay-actions">
+        <a class="btn" href="https://exposure.money">Start over</a>
+      </div>
+    </div>
 
-    <a href="https://exposure.money"><button>Start over</button></a></h2>
-    <!-- TODO more explaination -->
-  </div>
+    <!-- Pay state -->
+    <div id="pay" class="pay-screen" style="display:none;">
+      <p class="eyebrow">You've been paid in Exposure</p>
+      <p class="pay-to">Pay <strong class="username">someone</strong></p>
+      <h1 class="pay-amount"><span class="amount">0</span> <span style="font-size:0.4em;color:var(--muted);">Exposure</span></h1>
+      <p>One click converts it into the cold, hard currency of your choice.</p>
 
-  <div id="pay" style="display: none;">
-    <h2>The simplest, minimal payment system that allows creatives to get paid in Exposure. 📈👍</h2>
+      <div class="pay-actions">
+        <button type="button" id="button">Pay now →</button>
+      </div>
 
-    <p>Just click the button below to pay <strong class="username">username</strong> the amount of <strong class="amount">0</strong> Exposure!</p>
-
-    <button type="button" id="button">Pay with Exposure!</button>
-
-    <div style="margin-top: 30vh;">
-      <hr>
-      <p><a href="https://exposure.money" target="_blank">What is Exposure?</a> | <a href="https://www.youtube.com/watch?v=PBwAxmrE194" target="_blank">Why the Paypal Link?</a></p>
+      <footer class="pay-footer">
+        <p class="caption">
+          <a href="https://exposure.money" target="_blank" rel="noopener">What is Exposure?</a>
+          &nbsp;·&nbsp;
+          <a href="https://www.youtube.com/watch?v=PBwAxmrE194" target="_blank" rel="noopener">Why the PayPal link?</a>
+        </p>
+      </footer>
     </div>
   </div>
 
-  <script type="text/javascript">
-    function showError() {
-      $("#error").show();
-      return false;
-    }
+  <script>
+    (function () {
+      var errorEl = document.getElementById("error");
+      var payEl = document.getElementById("pay");
 
-    function showPaymentMessage(username, amount) {
-      $('#pay').find('.username').text(username);
-      $('#pay').find('.amount').text(amount);
+      function showError() {
+        errorEl.style.display = "flex";
+        return false;
+      }
 
-      $('#pay').show();
-    }
+      function decodeToken(token) {
+        // Inverse of the UTF-8 safe encoder used on the home page.
+        return decodeURIComponent(escape(window.atob(token)));
+      }
 
-    $(document).ready(function(){
-      var path = window.location.pathname.split('/');
-      var pathLength = path.length;
+      var path = window.location.pathname.split("/").filter(Boolean);
 
-      // Check we're meaning to pay:
-      if (pathLength < 2 || path[pathLength - 2] !== 'pay') {
+      // Expect .../pay/<token>
+      if (path.length < 2 || path[path.length - 2] !== "pay") {
         return showError();
       }
 
-      // Get the token:
-      var token = path[pathLength - 1];
+      var token = path[path.length - 1];
       var username, amount;
 
       try {
-        var decoded = window.atob(token);
-        var decodedParts = decoded.split(':');
-
-        username = decodedParts[0];
-        amount = decodedParts[1];
-      } catch(e) {
+        var parts = decodeToken(token).split(":");
+        username = parts[0];
+        amount = parts[1];
+      } catch (e) {
         return showError();
       }
 
@@ -250,15 +103,18 @@ div {
         return showError();
       }
 
-      showPaymentMessage(username, amount);
+      payEl.querySelector(".username").textContent = username;
+      payEl.querySelector(".amount").textContent = amount;
+      payEl.style.display = "flex";
 
-      $('#button').click(function(e) {
-        var username = $(".username").text();
-        var amount = $(".amount").text();
-        window.location = "https://www.paypal.me/"+username+"/"+amount;
+      document.getElementById("button").addEventListener("click", function () {
+        window.location =
+          "https://www.paypal.me/" +
+          encodeURIComponent(username) +
+          "/" +
+          encodeURIComponent(amount);
       });
-    });
+    })();
   </script>
 </body>
-
 </html>

--- a/index.html
+++ b/index.html
@@ -1,272 +1,170 @@
-    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="https://www.w3.org/1999/xhtml" >
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<title>Pay me in Exposure</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Exposure — get paid in Exposure</title>
 
-<script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
+  <meta name="description" content="The simplest, minimal payment system that lets creatives get paid in Exposure." />
+  <meta name="author" content="Exposure" />
 
+  <meta property="og:title" content="Exposure" />
+  <meta property="og:description" content="A simple, minimal payment system that lets you pay in Exposure." />
+  <meta property="og:url" content="https://exposure.money/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://github.com/danilosierrac/exposure/blob/master/exposure.png?raw=true" />
 
-<script type="text/javascript">
+  <meta name="twitter:site" content="@mimosaagency" />
+  <meta name="twitter:title" content="Exposure" />
+  <meta name="twitter:description" content="The simplest payment system." />
+  <meta name="twitter:url" content="https://exposure.money/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://github.com/danilosierrac/exposure/blob/master/exposure.png?raw=true" />
 
-$(document).ready(function(){
-
-    $('#button').click(function(e) {
-      var username = $("#input").val();
-      var amount = $("#input2").val();
-
-      var token = window.btoa(username + ':' + amount).replace(/\=*$/m, '');
-
-      $('.link').text('https://exposure.money/pay/'+token);
-    });
-});
-</script> 
-
-<meta name="description" content="The simplest payment processing system">
-<!-- <meta name="viewport" content="width=device-width, initial-scale=1"> -->
-  <meta name="author" content="Exposure"/>
-  <meta property="og:title" content="Exposure">
-  <meta property="og:description" content="A simple, minimal payment processing system that allows you to pay in Exposure."/>
-  <meta property="og:url" content="https://exposure.money/"/>
-  <meta property="og:type" content="website"/>
-  <meta property="og:image" content="https://github.com/danilosierrac/exposure/blob/master/exposure.png?raw=true"/>
-
-  <meta name="twitter:site" content="@mimosaagency"/>
-  <meta name="twitter:title" content="Exposure"/>
-  <meta name="twitter:description" content="The simplest payment processing system."/>
-  <meta name="twitter:url" content="https://exposure.money/"/>
-  <meta name="twitter:card" content="photo"/>
-  <meta name="twitter:image src" content="https://github.com/danilosierrac/exposure/blob/master/exposure.png?raw=true" />
-
-  <head profile="https://www.w3.org/2005/10/profile"/>
-  <link rel="icon" 
-      type="image/png" 
-      href="exposure.ico">
-<link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
-<style>
-body {
-  font-family: -apple-system, "San Francisco", BlinkMacSystemFont, “Segoe UI”, Roboto, Helvetica, Arial, sans-serif, “Apple Color Emoji”, “Segoe UI Emoji”, “Segoe UI Symbol”; 
-  max-width: 80%; 
-  margin-left: 10%;
-  word-wrap: break-word;
-}
-
-input[type="text"] 
-{
-  margin-top: 30px;
-  margin-bottom: 30px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 10px;
-  border: none;
-  text-align: left;
-  border-bottom: dashed 5px #FF2D55;
-  transition: border 0.3s;
-  color: #FF2D55;
-  word-wrap: break-word;
-  box-sizing : border-box;
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-  background-color: #ededed;
-}
-
-input[type="text"]:enabled,
-  input[type="text"].enabled {
-  margin-top: 30px;
-  margin-bottom: 30px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 10px;
-  border-bottom: dashed 5px #FF2D55;
-  font-size: 1em;
-  color: #FF2D55;
-  word-wrap: break-word;
-  box-sizing : border-box;
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-  background-color: #ededed;
-}
-
-  input[type="text"]:focus,
-  input[type="text"].focus {
-
-  margin-top: 30px;
-  margin-bottom: 30px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 10px;
-  border-bottom: dashed 5px #FF2D55;
-  font-size: 1em;
-  color: #FF2D55;
-  word-wrap: break-word;
-  box-sizing : border-box;
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-  background-color: #ededed;
-}
-
-input[type="text"]:blur,
-  input[type="text"].blur {
-  margin-top: 30px;
-  margin-bottom: 30px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 10px;
-  margin-bottom: 20px;
-  border-bottom: solid 5px #FF2D55;
-  font-size: 1.8em;
-  color: #FF2D55;
-  word-wrap: break-word;
-  box-sizing : border-box;
-  background-color: #ededed;
-}
-
-Button {
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-  background-color:#ff2d54;
-  display:inline-block;
-  cursor:pointer;
-  color:#ffffff;
-  font-family:Arial;
-  font-size:17px;
-  padding:16px 31px;
-  text-decoration:none;
-  border: none;
-  font-size: 3em;
-}
-
-Button:hover {
-  background-color:#ff2d54;
-}
-Button:active {
-  position:relative;
-  top:1px;
-}
-
-
-hr 
-{
-   border: 0;
-    height: 2px;
-    background: #333;
-    background-color: #333;
-}
-
-h1{
-  font-size: 8em;
-  color: #FF2D55;
-  text-decoration: underline;
-}
-
-h2 {
-  font-size: 4em;
-}
-
-p {
-  font-size: 3em;
-}
-
-pre{
-  margin-top: 30px;
-  padding: 20px 10px 20px 10px;
-  color: #FF2D55;
-  background-color: transparent;
-  background-color: #ededed;
-  outline: 0;
-  border-radius: 0;
-  resize: both;
-  overflow: auto;
-  font-size: 3em;
-  border-bottom: dashed 5px #FF2D55;
-  box-sizing : border-box;
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-}
-
-div {
-/*  padding-top: 2%;*/
-  padding-bottom: 5%;
-  margin: auto;
-}
-</style>
-
+  <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  <link rel="profile" href="https://www.w3.org/2005/10/profile" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
 </head>
+
 <body>
-      <p style= "text-align:right">🤑🔊</p>
-      <div>
-      <h1>Exposure</h1>
-      <h2>The simplest, minimal payment system that allows creatives to get paid in Exposure. 📈👍</h2>
+  <!-- Reusable flat-geometric motifs -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+    <defs>
+      <g id="bloom">
+        <circle cx="50" cy="18" r="15" /><circle cx="50" cy="82" r="15" />
+        <circle cx="18" cy="50" r="15" /><circle cx="82" cy="50" r="15" />
+        <circle cx="27" cy="27" r="15" /><circle cx="73" cy="27" r="15" />
+        <circle cx="27" cy="73" r="15" /><circle cx="73" cy="73" r="15" />
+      </g>
+      <g id="burst">
+        <path d="M50 4 58 38 92 30 66 52 88 80 54 66 50 96 46 66 12 80 34 52 8 30 42 38Z" />
+      </g>
+      <g id="petal">
+        <ellipse cx="50" cy="22" rx="13" ry="22" /><ellipse cx="50" cy="78" rx="13" ry="22" />
+        <ellipse cx="22" cy="50" rx="22" ry="13" /><ellipse cx="78" cy="50" rx="22" ry="13" />
+      </g>
+    </defs>
+  </svg>
+
+  <div class="wrap">
+    <header class="topbar">
+      <span class="mark">Exposure</span>
+      <span class="caption">exposure.money</span>
+    </header>
+
+    <!-- Masthead motif grid -->
+    <div class="tiles" aria-hidden="true">
+      <div class="tile marigold"><svg viewBox="0 0 100 100"><use href="#bloom" fill="#ff2d55"/><circle cx="50" cy="50" r="20" fill="#ff2d55"/><circle cx="50" cy="50" r="9" fill="#ffb12e"/></svg></div>
+      <div class="tile paper"></div>
+      <div class="tile blue"><svg viewBox="0 0 100 100"><use href="#petal" fill="#9fc0ff"/><use href="#burst" fill="#2f5bea"/></svg></div>
+      <div class="tile hotpink hide-sm"><svg viewBox="0 0 100 100"><use href="#petal" fill="#ff2d55"/><circle cx="50" cy="50" r="14" fill="#ffb12e"/></svg></div>
+      <div class="tile green"><svg viewBox="0 0 100 100"><use href="#bloom" fill="#ffb12e"/><circle cx="50" cy="50" r="14" fill="#ff2d55"/></svg></div>
+      <div class="tile pink hide-sm"><svg viewBox="0 0 100 100"><use href="#burst" fill="#ffb12e"/></svg></div>
+    </div>
+
+    <!-- Hero -->
+    <section class="hero">
+      <div class="hero-row">
+        <h1 class="display">Exposure</h1>
+        <p class="lede">A payment system for creatives who are tired of being paid in&nbsp;exposure.</p>
       </div>
+    </section>
 
+    <!-- Generator -->
+    <section>
+      <p class="eyebrow">Step 1 — Generate your link</p>
+      <div class="card">
+        <div class="field">
+          <label for="amount">The amount you want — in Exposure</label>
+          <input type="text" id="amount" inputmode="decimal" placeholder="100" autocomplete="off" />
+          <span class="hint">Exchange rate: 1 Exposure = 1 unit of your PayPal currency. Forever.</span>
+        </div>
 
-      <h1>Get paid</h1>
-      <h2>1. Generate your payment link</h2>
-      <p><strong>Amount of money you want in Exposure:
-       <br>
-        <input type="text" placeholder="Insert Amount $$$" onfocus="this.placeholder = ''" onblur="this.placeholder = 'Insert Amount $$$' "id="input2">
-      <br>Paypal user ID where the money will go to:
-        <br>
-        <input type="text" placeholder="Paypal.me/myuserID" onfocus="this.placeholder = ''" onblur="this.placeholder = 'Paypal.me/myuserID' "id="input"></strong>
-        <br>
-        You only need to input the user ID part, your link will appear below the button.
-        </p>
-       <button type="link" id="button">Generate Exposure link ↓</button>
-       <pre class="link" >Your link will appear here!</pre>
-       
-       <h2>2. Copy and paste the link on another tab for testing</h2>
-       
-       <p>You can try this link in another tab before you send it. It has to redirect to a checkout page with a button that redirects to your Paypal.me page including the amount you want in real currency. Your link is ready to send!</p>
-       <h2>3. Send the link</h2>
-       
-       <p>Now your prospective "client" can pay you in Exposure that converts to real money. Thank you for using Exposure!</p>
-      <br>
-      <br>
-      <br>
-      <br>
-      <br>
-      <br>
-      <h1>How it Works</h1>
-      
-      <p>Your paypal.me user ID works as your Exposure user ID (The one right after your link paypal.me/youruserID).</p>
-      
-      <p>Just input your user ID along with the amount of money in Exposure the work is worth in money to generate a payment link. We handle the rest!</p>
-      
-      <h2>Exchange rate</h2> 
-      
-      <p>Exposure's exchange rate is 1 Exposure = 1 unit of your selected Paypal currency. Forever.</p>
+        <div class="field">
+          <label for="username">Your PayPal.Me user ID</label>
+          <input type="text" id="username" placeholder="myuserID" autocomplete="off" />
+          <span class="hint">Only the ID part — the bit after paypal.me/</span>
+        </div>
 
-      <h2>Don't have a Paypal ID?</h2>
-      
-      <p><a href="https://www.paypal.me/">This is how you can get paid with a Paypal.me user ID</a></p>
-      
-      <p>Exposure is built for creatives tired of dealing with the exchange rate of Exposure in potential projects and markets.</p>
-      
-      <p>Simply send your paypal.me ID and the amount of Exposure you want to get paid to your client. Our redirection tool will convert your Exposure into real cash.</p>
-      
-      <h2>Something's wrong?</h2>
-      
-      <p>Then send them our preferred payment method:💸💸💸💸💸💸💸💸💸💸</p>
-      
-      <h2>Why</h2>
-      
-      <p>because <a href="https://www.youtube.com/watch?v=PBwAxmrE194">C.R.E.A.M.</a></p>
-      <h2>Accept only cold hard Exposure or cash. Ideally in advance...</h2>
-      
-      <div>
-      <h1>Disclaimer</h1> 
-      <h2>We make nothing out of this but disrupt the Exposure market.</h2> 
+        <button type="button" id="generate">Generate Exposure link</button>
 
-      <p>All work has to be financially compensated. The link is generated by a simple javascript script and we don't keep nor track any information about you or anything else. Everything done here never leaves your browser. In case of doubt, feel free to check the code <a href="https://github.com/danilosierrac/exposure">here</a>.</p>
-      
-      <p>We have no association wit Paypal. Don't @ us.</p>
-      
-      <p>Made by <a href="https://mimosaagency.com/">mimosa agency</a> with parody intentions.</p> 
-      <p/>We advocate for the fair payment of labor in the commonly agreed terms between client and provider that allows the provider to live of their labor.</p>
+        <div class="result">
+          <p class="eyebrow">Your shareable link</p>
+          <pre class="link placeholder" id="output">Fill in the fields above, then hit generate.</pre>
+        </div>
       </div>
+    </section>
+
+    <!-- Steps -->
+    <section class="section">
+      <h2>2. Test it before you send</h2>
+      <p>Open the link in another tab. It lands on a clean checkout page with a single button that forwards your "client" to your PayPal.Me page, amount pre-filled. If it works, it's ready to send.</p>
+
+      <h2>3. Send it</h2>
+      <p>Now your prospective client can finally pay you in Exposure — the kind that converts to real money. You're welcome.</p>
+    </section>
+
+    <!-- How it works -->
+    <section class="section">
+      <h2>How it works</h2>
+      <p>Your PayPal.Me user ID doubles as your Exposure user ID — it's the part right after <strong>paypal.me/</strong>. Enter it with the amount your work is actually worth, and we build the link. We handle the rest.</p>
+
+      <h3>Don't have a PayPal ID?</h3>
+      <p><a href="https://www.paypal.me/" target="_blank" rel="noopener">Here's how to get paid with a PayPal.Me ID.</a></p>
+
+      <h3>Something's wrong?</h3>
+      <p>Then send them our preferred backup payment method: 💸💸💸💸💸💸💸💸</p>
+
+      <h3>Why</h3>
+      <p>Because <a href="https://www.youtube.com/watch?v=PBwAxmrE194" target="_blank" rel="noopener">C.R.E.A.M.</a> Accept only cold hard Exposure or cash — ideally in advance.</p>
+    </section>
+
+    <!-- Disclaimer -->
+    <footer class="disclaimer">
+      <h2 class="display">Disclaimer</h2>
+      <p>We make nothing out of this but a dent in the Exposure market. The link is generated by a small script that runs entirely in your browser — we don't keep or track anything about you. In case of doubt, <a href="https://github.com/danilosierrac/exposure" target="_blank" rel="noopener">read the code</a>.</p>
+      <p>We have no association with PayPal. Don't @ us.</p>
+      <p>We advocate for the fair payment of labor on terms agreed between client and provider that let the provider live off their work.</p>
+      <p>Made by <a href="https://mimosaagency.com/" target="_blank" rel="noopener">mimosa agency</a>, with parody intentions.</p>
+    </footer>
+  </div>
+
+  <script>
+    (function () {
+      var amountEl = document.getElementById("amount");
+      var usernameEl = document.getElementById("username");
+      var output = document.getElementById("output");
+
+      function encodeToken(username, amount) {
+        // UTF-8 safe base64; keep padding so the pay page can decode it.
+        return btoa(unescape(encodeURIComponent(username + ":" + amount)));
+      }
+
+      function generate() {
+        var amount = amountEl.value.trim();
+        var username = usernameEl.value.trim().replace(/^.*paypal\.me\//i, "");
+
+        if (!username || !amount) {
+          output.textContent = "Add both an amount and a PayPal.Me ID first.";
+          output.classList.add("placeholder");
+          return;
+        }
+
+        var token = encodeToken(username, amount);
+        output.textContent = "https://exposure.money/pay/" + token;
+        output.classList.remove("placeholder");
+      }
+
+      document.getElementById("generate").addEventListener("click", generate);
+      [amountEl, usernameEl].forEach(function (el) {
+        el.addEventListener("keydown", function (e) {
+          if (e.key === "Enter") generate();
+        });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/local-server.js
+++ b/local-server.js
@@ -1,13 +1,33 @@
+// Minimal static server for local testing.
+// Mirrors GitHub Pages: unknown paths fall through to 404.html,
+// which is what powers the client-side /pay/<token> route.
 var http = require('http');
 var fs = require('fs');
+var path = require('path');
 
-http.createServer(function(req, res) {
-    console.log(req.url);
+var TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon'
+};
 
-    if (req.url === '/') {
-        res.end(fs.readFileSync('index.html'));
-        return;
+http.createServer(function (req, res) {
+  console.log(req.url);
+
+  var url = req.url.split('?')[0];
+  var file = url === '/' ? 'index.html' : path.normalize(url).replace(/^(\.\.[\/\\])+/, '').slice(1);
+
+  fs.readFile(file, function (err, data) {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': TYPES['.html'] });
+      res.end(fs.readFileSync('404.html'));
+      return;
     }
-
-    res.end(fs.readFileSync('404.html'));
-}).listen(8000)
+    res.writeHead(200, { 'Content-Type': TYPES[path.extname(file)] || 'application/octet-stream' });
+    res.end(data);
+  });
+}).listen(8000, function () {
+  console.log('Serving on http://localhost:8000');
+});

--- a/style.css
+++ b/style.css
@@ -1,150 +1,390 @@
+/* Exposure — editorial restyle
+   Warm paper, flat bold color, serif display. */
+
+:root {
+  --paper: #f0eee6;
+  --paper-2: #e7e4d8;
+  --ink: #16130f;
+  --muted: #6f6a60;
+  --pink: #ff2d55;
+  --blue: #2f5bea;
+  --marigold: #ffb12e;
+  --green: #0e8a5f;
+  --hotpink: #ff59a6;
+  --line: #d8d4c6;
+
+  --maxw: 760px;
+  --serif: "Fraunces", "Hoefler Text", Georgia, "Times New Roman", serif;
+  --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
 body {
-  font-family: -apple-system, "San Francisco", BlinkMacSystemFont, “Segoe UI”, Roboto, Helvetica, Arial, sans-serif, “Apple Color Emoji”, “Segoe UI Emoji”, “Segoe UI Symbol”; 
-  max-width: 80%; 
-  margin-left: 10%;
-  word-wrap: break-word;
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 18px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-input[type="text"] 
-{
-  margin-top: 30px;
-  margin-bottom: 30px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 10px;
-  border: none;
-  text-align: left;
-  border-bottom: dashed 5px #FF2D55;
-  transition: border 0.3s;
-  color: #FF2D55;
-  word-wrap: break-word;
-  box-sizing : border-box;
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-  background-color: #ededed;
+.wrap {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 24px;
 }
 
-input[type="text"]:enabled,
-  input[type="text"].enabled {
-  margin-top: 30px;
-  margin-bottom: 30px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 10px;
-  border-bottom: dashed 5px #FF2D55;
-  font-size: 1em;
-  color: #FF2D55;
-  word-wrap: break-word;
-  box-sizing : border-box;
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-  background-color: #ededed;
+/* ---- Typography ---- */
+
+h1,
+h2,
+h3 {
+  font-family: var(--serif);
+  font-weight: 600;
+  line-height: 1.04;
+  letter-spacing: -0.015em;
+  margin: 0;
 }
 
-  input[type="text"]:focus,
-  input[type="text"].focus {
-
-  margin-top: 30px;
-  margin-bottom: 30px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 10px;
-  border-bottom: dashed 5px #FF2D55;
-  font-size: 1em;
-  color: #FF2D55;
-  word-wrap: break-word;
-  box-sizing : border-box;
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-  background-color: #ededed;
-}
-
-input[type="text"]:blur,
-  input[type="text"].blur {
-  margin-top: 30px;
-  margin-bottom: 30px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 10px;
-  margin-bottom: 20px;
-  border-bottom: solid 5px #FF2D55;
-  font-size: 1.8em;
-  color: #FF2D55;
-  word-wrap: break-word;
-  box-sizing : border-box;
-  background-color: #ededed;
-}
-
-Button {
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
-  background-color:#ff2d54;
-  display:inline-block;
-  cursor:pointer;
-  color:#ffffff;
-  font-family:Arial;
-  font-size:17px;
-  padding:16px 31px;
-  text-decoration:none;
-  border: none;
-  font-size: 3em;
-}
-
-Button:hover {
-  background-color:#ff2d54;
-}
-Button:active {
-  position:relative;
-  top:1px;
-}
-
-
-hr 
-{
-   border: 0;
-    height: 2px;
-    background: #333;
-    background-color: #333;
-}
-
-h1{
-  font-size: 8em;
-  color: #FF2D55;
-  text-decoration: underline;
+.display {
+  font-size: clamp(3.2rem, 13vw, 7.5rem);
+  font-weight: 600;
+  font-style: normal;
 }
 
 h2 {
-  font-size: 4em;
+  font-size: clamp(1.5rem, 4.5vw, 2.4rem);
+  margin-top: 2.6em;
+  margin-bottom: 0.5em;
+}
+
+h3 {
+  font-size: 1.25rem;
+  margin-top: 2em;
+  margin-bottom: 0.4em;
 }
 
 p {
-  font-size: 3em;
+  margin: 0 0 1.1em;
+  max-width: 60ch;
 }
 
-pre{
-  margin-top: 30px;
-  padding: 20px 10px 20px 10px;
-  color: #FF2D55;
-  background-color: transparent;
-  background-color: #ededed;
-  outline: 0;
-  border-radius: 0;
-  resize: both;
-  overflow: auto;
-  font-size: 3em;
-  border-bottom: dashed 5px #FF2D55;
-  box-sizing : border-box;
-  -moz-box-shadow: 4px 3px 0px 0px #2c292e;
-  -webkit-box-shadow: 4px 3px 0px 0px #2c292e;
-  box-shadow: 4px 3px 0px 0px #2c292e;
+.lede {
+  font-family: var(--serif);
+  font-size: clamp(1.3rem, 3.5vw, 1.9rem);
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  font-weight: 400;
+  color: var(--ink);
+  max-width: 22ch;
 }
 
-div {
-/*  padding-top: 2%;*/
-  padding-bottom: 5%;
-  margin: auto;
+a {
+  color: var(--pink);
+  text-decoration: none;
+  border-bottom: 1.5px solid currentColor;
+  padding-bottom: 1px;
+  transition: opacity 0.15s ease;
+}
+
+a:hover {
+  opacity: 0.6;
+}
+
+strong {
+  font-weight: 600;
+}
+
+.eyebrow {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0;
+}
+
+.caption {
+  font-size: 0.82rem;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+/* ---- Top bar ---- */
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 28px 0 0;
+}
+
+.topbar .mark {
+  font-family: var(--serif);
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  border: 0;
+}
+
+/* ---- Decorative tile grid (masthead motif) ---- */
+
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 10px;
+  margin: 40px 0 8px;
+}
+
+.tile {
+  aspect-ratio: 1 / 1;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.tile svg {
+  width: 64%;
+  height: 64%;
+  display: block;
+}
+
+.tile.empty {
+  background: transparent;
+}
+.tile.paper {
+  background: var(--paper-2);
+}
+.tile.pink {
+  background: var(--pink);
+}
+.tile.blue {
+  background: var(--blue);
+}
+.tile.marigold {
+  background: var(--marigold);
+}
+.tile.green {
+  background: var(--green);
+}
+.tile.hotpink {
+  background: var(--hotpink);
+}
+
+@media (max-width: 560px) {
+  .tiles {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+  }
+  .tile.hide-sm {
+    display: none;
+  }
+}
+
+/* ---- Hero ---- */
+
+.hero {
+  padding: 26px 0 10px;
+}
+
+.hero .display {
+  margin-bottom: 0.18em;
+}
+
+.hero-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px 48px;
+  align-items: end;
+  justify-content: space-between;
+}
+
+/* ---- Generator card ---- */
+
+.card {
+  background: #fbfaf5;
+  border: 1.5px solid var(--ink);
+  border-radius: 10px;
+  padding: 34px 30px;
+  margin: 18px 0 8px;
+  box-shadow: 8px 8px 0 var(--ink);
+}
+
+.steps {
+  counter-reset: step;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.field {
+  margin: 0 0 22px;
+}
+
+.field label {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  margin-bottom: 8px;
+}
+
+.field .hint {
+  display: block;
+  font-weight: 400;
+  color: var(--muted);
+  font-size: 0.82rem;
+  margin-top: 6px;
+}
+
+input[type="text"] {
+  width: 100%;
+  font-family: var(--serif);
+  font-size: 1.5rem;
+  color: var(--ink);
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid var(--line);
+  padding: 6px 2px 8px;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+input[type="text"]::placeholder {
+  color: #b7b2a4;
+}
+
+input[type="text"]:focus {
+  border-bottom-color: var(--pink);
+}
+
+button,
+.btn {
+  font-family: var(--sans);
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: #fff;
+  background: var(--ink);
+  border: 0;
+  border-radius: 999px;
+  padding: 15px 28px;
+  cursor: pointer;
+  display: inline-block;
+  transition: transform 0.08s ease, background 0.15s ease;
+}
+
+button:hover,
+.btn:hover {
+  background: var(--pink);
+  opacity: 1;
+}
+
+button:active,
+.btn:active {
+  transform: translateY(1px);
+}
+
+.btn {
+  border-bottom: 0;
+}
+
+/* ---- Link output ---- */
+
+.result {
+  margin-top: 26px;
+  border-top: 1.5px dashed var(--line);
+  padding-top: 20px;
+}
+
+.result .eyebrow {
+  margin-bottom: 8px;
+}
+
+.link {
+  font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas,
+    monospace;
+  font-size: 1rem;
+  color: var(--pink);
+  background: var(--paper);
+  border-radius: 6px;
+  padding: 14px 16px;
+  margin: 0;
+  word-break: break-all;
+  white-space: pre-wrap;
+  line-height: 1.45;
+}
+
+.link.placeholder {
+  color: var(--muted);
+}
+
+/* ---- Sections / footer ---- */
+
+.section {
+  border-top: 1.5px solid var(--line);
+  margin-top: 64px;
+  padding-top: 8px;
+}
+
+.disclaimer {
+  margin: 90px 0 60px;
+  padding-top: 28px;
+  border-top: 1.5px solid var(--ink);
+}
+
+.disclaimer p {
+  font-size: 0.92rem;
+  color: var(--muted);
+  max-width: 64ch;
+}
+
+.disclaimer .display {
+  font-size: clamp(2rem, 7vw, 3.4rem);
+}
+
+/* ---- Pay page ---- */
+
+.pay-screen {
+  min-height: 100svh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 60px 0;
+}
+
+.pay-amount {
+  font-family: var(--serif);
+  font-size: clamp(3rem, 14vw, 7rem);
+  line-height: 1;
+  letter-spacing: -0.02em;
+  margin: 0.1em 0 0.05em;
+}
+
+.pay-to {
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.pay-actions {
+  margin-top: 32px;
+}
+
+.pay-footer {
+  margin-top: auto;
+  padding-top: 48px;
+  border-top: 1.5px solid var(--line);
 }


### PR DESCRIPTION
## What this does

A visual redesign of the Exposure parody site plus the quick fixes we discussed.

### New look
Inspired by flat-color editorial layouts (bold blocks on warm paper, serif display, restrained captioning):
- Warm paper background, **Fraunces** serif for display type, a tight editorial copy scale
- A bold flat-color **tile-grid masthead** built from reusable inline SVG motifs (no image assets, no template smell)
- Refined generator card (offset shadow, serif inputs with focus underline), pill buttons, and a redesigned full-screen pay page
- Single shared `style.css` with CSS custom properties for the palette

### Fixes
- **Mobile viewport** meta tag added (headings no longer blow out the layout on phones)
- **Favicon** now points at the file that actually exists (`favicon.ico`, not the missing `exposure.ico`)
- **De-duplicated CSS** — one `style.css` linked from both pages, removing the triplicated inline copies
- **Dropped jQuery** — both pages now use small vanilla JS
- **base64 bug fixed** — stopped stripping `=` padding (which broke `atob` for some lengths) and made encode/decode UTF-8 safe so non-ASCII handles/amounts round-trip
- Input now tolerates a pasted `paypal.me/...` prefix
- Copy typos fixed ("wit Paypal" → "with PayPal"), invalid duplicate `<head>` and stray `<p/>` removed, HTML5 doctype
- Dev `local-server.js` now serves real static files with correct content types (so `style.css` loads locally), still falling through to `404.html` like GitHub Pages

### Testing
- base64 encode→decode round-trips verified across padding and unicode cases
- Local server confirmed serving `index.html`, `style.css`, and `favicon.ico` with correct content types, and the `/pay/<token>` route falling through to `404.html`
- No browser available in this environment, so visual rendering hasn't been screenshotted — worth a local look before merging

https://claude.ai/code/session_016RxGqrmYU7SFzLMwX22bSJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016RxGqrmYU7SFzLMwX22bSJ)_